### PR TITLE
iOS RemoteDrviver Appium support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.gem
 *.rbc
 .bundle
+.idea
 .config
 .yardoc
 Gemfile.lock

--- a/features/mobile_remote.feature
+++ b/features/mobile_remote.feature
@@ -1,26 +1,27 @@
 Feature: RDee should work well with mobile devices on a remote selenium grid
 
-  Scenario: Creating an iPhone browser on ios 7.1
-    When I establish a iphone_ios71 browser on the remote machine using Selenium
+  Scenario: Creating an iPhone 6 browser on ios 8.2
+    When I establish a ios8.0_iphone_6 browser on the remote machine using Selenium
     And I go to the cheezyworld site
     And I select the transformations link
     Then I should see the text "Cucumber Transformations Screencast"
 
-  Scenario: Creating an iPhone browser on ios 7.0
-    When I establish a iphone_ios70 browser on the remote machine using Selenium
+  Scenario: Creating an iPhone 5 browser on ios 8.2
+    When I establish a ios8.1_iphone_5 browser on the remote machine using Selenium
     And I go to the cheezyworld site
     And I select the transformations link
     Then I should see the text "Cucumber Transformations Screencast"
 
-  Scenario: Creating an iPhone browser on ios 6.1
-    When I establish a iphone_ios61 browser on the remote machine using Selenium
+  Scenario: Creating an iPad Air 2 browser on ios 9.0
+    When I establish a ios9.0_iphone_air_2 browser on the remote machine using Selenium
     And I go to the cheezyworld site
     And I select the transformations link
     Then I should see the text "Cucumber Transformations Screencast"
 
-  Scenario: Creating an iPhone browser on ios 6.0
-    When I establish a iphone_ios60 browser on the remote machine using Selenium
+  Scenario: Creating an iPad Pro browser on ios 9.2
+    When I establish a ios9.2_ipad_pro browser on the remote machine using Selenium
     And I go to the cheezyworld site
     And I select the transformations link
     Then I should see the text "Cucumber Transformations Screencast"
+
 

--- a/lib/rdee/browser_factory.rb
+++ b/lib/rdee/browser_factory.rb
@@ -64,9 +64,21 @@ module RDee
     end
 
     def capabilities(platform, version, host)
-      capabilities = Selenium::WebDriver::Remote::Capabilities.send platform
+      if platform == :ios
+        host.downcase.include?('iphone') ? browser = 'iPhone' : browser = 'iPad'
+        capabilities = Selenium::WebDriver::Remote::Capabilities.send(browser.downcase,
+            {app: 'safari',
+             device: "#{host}",
+             platformName: 'iOS',
+             platformVersion: "#{version}",
+             deviceName: "#{host}",
+             browserName: "#{browser}"})
+        capabilities.platform = 'MAC'
+      else
+        capabilities = Selenium::WebDriver::Remote::Capabilities.send platform
+        capabilities.platform = host unless host.nil?
+      end
       capabilities.version = version unless version.nil?
-      capabilities.platform = host unless host.nil?
       capabilities
     end
 

--- a/lib/rdee/mobile_devices.rb
+++ b/lib/rdee/mobile_devices.rb
@@ -9,7 +9,7 @@ module RDee
     
     def mobile_targets
       @mobile_targets ||= [
-        :iphone
+        :ios
       ]
     end
     

--- a/lib/rdee/target_parser.rb
+++ b/lib/rdee/target_parser.rb
@@ -20,8 +20,8 @@ module RDee
     end
 
     def version_for(value)
-      version = mobile_version(value) if mobile?(value)
-      version = browser_version(value) unless mobile?(value)
+      #version = mobile_version(value) if mobile?(value)
+      version = browser_version(value) #unless mobile?(value)
       unless version.nil?
         version = nil if version.empty?
       end
@@ -37,9 +37,9 @@ module RDee
       value.to_s.gsub(target_for(value).to_s, '').split(/_/)[0]
     end
 
-    def mobile_version(value)
-      value.to_s.split(/_/).slice(1..-1)[0][-2,2].insert(1, '.')
-    end
+    #def mobile_version(value)
+    #  value.to_s.split(/_/).slice(1..-1)[0][-2,2].insert(1, '.')
+    #end
 
     def host_lookup
       @host_lookup ||= {
@@ -52,12 +52,18 @@ module RDee
         mavricks: 'OS X 10.9',
         yosemite: 'OS X 10.10',
         linux: 'Linux',
-        ios60: 'OS X 10.8',
-        ios61: 'OS X 10.8',
-        ios70: 'OS X 10.9',
-        ios71: 'OS X 10.9',
-        ios80: 'OS X 10.10',
-        ios81: 'OS X 10.10'
+        ipad_2: 'iPad 2',
+        ipad_air: 'iPad Air',
+        ipad_air_2: 'iPad Air 2',
+        ipad_retina: 'iPad Retina',
+        ipad_pro: 'iPad Pro',
+        iphone_4s: 'iPhone 4s',
+        iphone_5: 'iPhone 5',
+        iphone_5s: 'iPhone 5s',
+        iphone_6: 'iPhone 6',
+        iphone_6_plus: 'iPhone 6 Plus',
+        iphone_6s: 'iPhone 6s',
+        iphone_6s_plus: 'iPhone 6s Plus'
       }
     end
 


### PR DESCRIPTION
Hi @cheezy ,
I have finished my refactor to add Appium support to RDee. The cool thing about appium is that it can drive any iOS simulator that you have installed, so I took advantage of your 'host' mapping to use that for iOS devices. 

so now you can call this:

```
ios9.0_ipad_retina
```

and you will get the following extracted

```
version = 9.0
browser= iPad
device = iPad Retina
```

it works really nicely and I am very excited to have RDee working with Appium. I sidestepped the mobile version matcher but have left any sidestepped code as commented to help illustrate the changes. 
